### PR TITLE
add fullTitle property to tests

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -66,28 +66,28 @@ function Reporter(runner, options) {
   });
 
   runner.on('test end', (test) => {
-    currentSuite.tests.push(formatTest(test));
+    currentSuite.tests.push(formatTest(test, currentSuite));
   });
 
   runner.on('pass', (test) => {
-    passes.push(test);
+    passes.push(formatTest(test, currentSuite));
   });
 
   runner.on('fail', (test) => {
-    failures.push(test);
+    failures.push(formatTest(test, currentSuite));
   });
 
   runner.on('pending', (test) => {
-    pending.push(test);
+    pending.push(formatTest(test, currentSuite));
   });
 
   runner.once('end', () => {
     const obj = {
       stats: self.stats,
       suites,
-      pending: pending.map(formatTest),
-      failures: failures.map(formatTest),
-      passes: passes.map(formatTest),
+      pending: pending,
+      failures: failures,
+      passes: passes,
     };
 
     fs.writeFileSync(filePath, JSON.stringify(obj, null, 2));
@@ -104,7 +104,8 @@ const getTestResult = (test) => {
   return 'unknown';
 };
 
-const formatTest = (test) => ({
+const formatTest = (test, suite) => ({
+  fullTitle: `${suite.title} ${test.title}`,
   title: test.title,
   duration: test.duration,
   result: getTestResult(test),

--- a/test/validate-output-hierarchy.js
+++ b/test/validate-output-hierarchy.js
@@ -42,16 +42,18 @@ describe('reporter - hierarchy mode', function() {
         "title": "suite 1",
         "tests": [
           {
+            "fullTitle": "suite 1 test pass",
             "title": "test pass",
             "result": "passed",
             "err": {}
           },
           {
+            "fullTitle": "suite 1 test fail",
             "title": "test fail",
             "result": "failed",
             "err": {
-              "stack": `AssertionError [ERR_ASSERTION]: null == true\n    at Context.it (${path.join('test','sample-test.js')}:7:32)`,
-              "message": "null == true",
+              "stack": `AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert.ok(null)\n\n    at Context.it (${path.join('test','sample-test.js')}:7:32)`,
+              "message": "The expression evaluated to a falsy value:\n\n  assert.ok(null)\n",
               "generatedMessage": true,
               "name": "AssertionError [ERR_ASSERTION]",
               "code": "ERR_ASSERTION",
@@ -61,6 +63,7 @@ describe('reporter - hierarchy mode', function() {
             }
           },
           {
+            "fullTitle": "suite 1 skipped test",
             "title": "skipped test",
             "result": "pending",
             "err": {}
@@ -71,16 +74,18 @@ describe('reporter - hierarchy mode', function() {
             "title": "nested describe",
             "tests": [
               {
+                "fullTitle": "nested describe nested test pass",
                 "title": "nested test pass",
                 "result": "passed",
                 "err": {}
               },
               {
+                "fullTitle": "nested describe nested test fail",
                 "title": "nested test fail",
                 "result": "failed",
                 "err": {
-                  "stack": `AssertionError [ERR_ASSERTION]: null == true\n    at Context.it (${path.join('test','sample-test.js')}:11:41)`,
-                  "message": "null == true",
+                  "stack": `AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert.ok(null)\n\n    at Context.it (${path.join('test','sample-test.js')}:11:41)`,
+                  "message": "The expression evaluated to a falsy value:\n\n  assert.ok(null)\n",
                   "generatedMessage": true,
                   "name": "AssertionError [ERR_ASSERTION]",
                   "code": "ERR_ASSERTION",
@@ -96,6 +101,7 @@ describe('reporter - hierarchy mode', function() {
             "title": "nested describe 2",
             "tests": [
               {
+                "fullTitle": "nested describe 2 nested d2 test",
                 "title": "nested d2 test",
                 "result": "passed",
                 "err": {}
@@ -109,6 +115,7 @@ describe('reporter - hierarchy mode', function() {
         "title": "suite 2",
         "tests": [
           {
+            "fullTitle": "suite 2 suite2 pass",
             "title": "suite2 pass",
             "result": "passed",
             "err": {}
@@ -120,6 +127,7 @@ describe('reporter - hierarchy mode', function() {
     assert.deepEqual(contents.pending, [{
       "err": {},
       "result": "pending",
+      "fullTitle": "suite 1 skipped test",
       "title": "skipped test"
     }]);
     const failures = contents.failures.map(f => {
@@ -128,11 +136,12 @@ describe('reporter - hierarchy mode', function() {
     });
     assert.deepEqual(failures, [
       {
+        "fullTitle": "suite 1 test fail",
         "title": "test fail",
         "result": "failed",
         "err": {
-          "stack": `AssertionError [ERR_ASSERTION]: null == true\n    at Context.it (${path.join('test','sample-test.js')}:7:32)`,
-          "message": "null == true",
+          "stack": `AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert.ok(null)\n\n    at Context.it (${path.join('test','sample-test.js')}:7:32)`,
+          "message": "The expression evaluated to a falsy value:\n\n  assert.ok(null)\n",
           "generatedMessage": true,
           "name": "AssertionError [ERR_ASSERTION]",
           "code": "ERR_ASSERTION",
@@ -142,11 +151,12 @@ describe('reporter - hierarchy mode', function() {
         }
       },
       {
+        "fullTitle": "nested describe nested test fail",
         "title": "nested test fail",
         "result": "failed",
         "err": {
-          "stack": `AssertionError [ERR_ASSERTION]: null == true\n    at Context.it (${path.join('test','sample-test.js')}:11:41)`,
-          "message": "null == true",
+          "stack": `AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert.ok(null)\n\n    at Context.it (${path.join('test','sample-test.js')}:11:41)`,
+          "message": "The expression evaluated to a falsy value:\n\n  assert.ok(null)\n",
           "generatedMessage": true,
           "name": "AssertionError [ERR_ASSERTION]",
           "code": "ERR_ASSERTION",
@@ -163,21 +173,25 @@ describe('reporter - hierarchy mode', function() {
     });;
     assert.deepEqual(passes, [
       {
+        "fullTitle": "suite 1 test pass",
         "title": "test pass",
         "result": "passed",
         "err": {}
       },
       {
+        "fullTitle": "nested describe nested test pass",
         "title": "nested test pass",
         "result": "passed",
         "err": {}
       },
       {
+        "fullTitle": "nested describe 2 nested d2 test",
         "title": "nested d2 test",
         "result": "passed",
         "err": {}
       },
       {
+        "fullTitle": "suite 2 suite2 pass",
         "title": "suite2 pass",
         "result": "passed",
         "err": {}

--- a/test/validate-output.js
+++ b/test/validate-output.js
@@ -38,16 +38,18 @@ describe('reporter - no hierarchy mode', function() {
         "title": "suite 1",
         "tests": [
           {
+            "fullTitle": "suite 1 test pass",
             "title": "test pass",
             "result": "passed",
             "err": {}
           },
           {
+            "fullTitle": "suite 1 test fail",
             "title": "test fail",
             "result": "failed",
             "err": {
-              "stack": `AssertionError [ERR_ASSERTION]: null == true\n    at Context.it (${path.join('test','sample-test.js')}:7:32)`,
-              "message": "null == true",
+              "stack": `AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert.ok(null)\n\n    at Context.it (${path.join('test','sample-test.js')}:7:32)`,
+              "message": "The expression evaluated to a falsy value:\n\n  assert.ok(null)\n",
               "generatedMessage": true,
               "name": "AssertionError [ERR_ASSERTION]",
               "code": "ERR_ASSERTION",
@@ -57,6 +59,7 @@ describe('reporter - no hierarchy mode', function() {
             }
           },
           {
+            "fullTitle": "suite 1 skipped test",
             "title": "skipped test",
             "result": "pending",
             "err": {}
@@ -67,16 +70,18 @@ describe('reporter - no hierarchy mode', function() {
         "title": "nested describe",
         "tests": [
           {
+            "fullTitle": "nested describe nested test pass",
             "title": "nested test pass",
             "result": "passed",
             "err": {}
           },
           {
+            "fullTitle": "nested describe nested test fail",
             "title": "nested test fail",
             "result": "failed",
             "err": {
-              "stack": `AssertionError [ERR_ASSERTION]: null == true\n    at Context.it (${path.join('test','sample-test.js')}:11:41)`,
-              "message": "null == true",
+              "stack": `AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert.ok(null)\n\n    at Context.it (${path.join('test','sample-test.js')}:11:41)`,
+              "message": "The expression evaluated to a falsy value:\n\n  assert.ok(null)\n",
               "generatedMessage": true,
               "name": "AssertionError [ERR_ASSERTION]",
               "code": "ERR_ASSERTION",
@@ -91,6 +96,7 @@ describe('reporter - no hierarchy mode', function() {
         "title": "nested describe 2",
         "tests": [
           {
+            "fullTitle": "nested describe 2 nested d2 test",
             "title": "nested d2 test",
             "result": "passed",
             "err": {}
@@ -101,6 +107,7 @@ describe('reporter - no hierarchy mode', function() {
         "title": "suite 2",
         "tests": [
           {
+            "fullTitle": "suite 2 suite2 pass",
             "title": "suite2 pass",
             "result": "passed",
             "err": {}
@@ -111,6 +118,7 @@ describe('reporter - no hierarchy mode', function() {
     assert.deepEqual(contents.pending, [{
       "err": {},
       "result": "pending",
+      "fullTitle": "suite 1 skipped test",
       "title": "skipped test"
     }]);
     const failures = contents.failures.map(f => {
@@ -119,11 +127,12 @@ describe('reporter - no hierarchy mode', function() {
     });
     assert.deepEqual(failures, [
       {
+        "fullTitle": "suite 1 test fail",
         "title": "test fail",
         "result": "failed",
         "err": {
-          "stack": `AssertionError [ERR_ASSERTION]: null == true\n    at Context.it (${path.join('test','sample-test.js')}:7:32)`,
-          "message": "null == true",
+          "stack": `AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert.ok(null)\n\n    at Context.it (${path.join('test','sample-test.js')}:7:32)`,
+          "message": "The expression evaluated to a falsy value:\n\n  assert.ok(null)\n",
           "generatedMessage": true,
           "name": "AssertionError [ERR_ASSERTION]",
           "code": "ERR_ASSERTION",
@@ -133,11 +142,12 @@ describe('reporter - no hierarchy mode', function() {
         }
       },
       {
+        "fullTitle": "nested describe nested test fail",
         "title": "nested test fail",
         "result": "failed",
         "err": {
-          "stack": `AssertionError [ERR_ASSERTION]: null == true\n    at Context.it (${path.join('test','sample-test.js')}:11:41)`,
-          "message": "null == true",
+          "stack": `AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:\n\n  assert.ok(null)\n\n    at Context.it (${path.join('test','sample-test.js')}:11:41)`,
+          "message": "The expression evaluated to a falsy value:\n\n  assert.ok(null)\n",
           "generatedMessage": true,
           "name": "AssertionError [ERR_ASSERTION]",
           "code": "ERR_ASSERTION",
@@ -154,21 +164,25 @@ describe('reporter - no hierarchy mode', function() {
     });;
     assert.deepEqual(passes, [
       {
+        "fullTitle": "suite 1 test pass",
         "title": "test pass",
         "result": "passed",
         "err": {}
       },
       {
+        "fullTitle": "nested describe nested test pass",
         "title": "nested test pass",
         "result": "passed",
         "err": {}
       },
       {
+        "fullTitle": "nested describe 2 nested d2 test",
         "title": "nested d2 test",
         "result": "passed",
         "err": {}
       },
       {
+        "fullTitle": "suite 2 suite2 pass",
         "title": "suite2 pass",
         "result": "passed",
         "err": {}


### PR DESCRIPTION
I've added the fullTitle property to the tests. This closes #7 
Also had to change the error messages in the expected output due to improved assertion errors introduced in node 10 by https://github.com/nodejs/node/commit/f76ef504326f8a37cdb0d3dae705239d685abffc

Would appreciate a merge and publish since the current behavior breaks Bamboo's mocha parser.